### PR TITLE
Fix background image positioning

### DIFF
--- a/src/templates/motivation.html
+++ b/src/templates/motivation.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="styles.css"/>
     <style>
       body {
-        background: url('img/crab-{{image}}.jpg'); 
+        background: url('img/crab-{{image}}.jpg') no-repeat center center fixed; 
         background-size: cover;
       }
     </style>


### PR DESCRIPTION
This fixes the image positioning to always fill the background rather than repeat if the viewport is larger than the image height.

## Before
<img width="1203" alt="Screenshot 2019-11-12 at 13 37 40" src="https://user-images.githubusercontent.com/4464295/68672425-e3c43d00-0551-11ea-876b-5b31847349ef.png">

## After
<img width="1203" alt="Screenshot 2019-11-12 at 13 38 08" src="https://user-images.githubusercontent.com/4464295/68672445-e9218780-0551-11ea-81f0-5a2cebdaa8d7.png">
